### PR TITLE
fix(maxDate): properly consider year when handling maxDate attribute …

### DIFF
--- a/src/auro-calendar.js
+++ b/src/auro-calendar.js
@@ -108,16 +108,22 @@ export class AuroCalendar extends RangeDatepicker {
     // handle latest month
     if (this.maxDate) {
       const maxMonth = new Date(this.maxDate).getMonth() + 1;
-      let lastViewedMonth = this.month + this.numCalendars - 1;
+      const maxYear = new Date(this.maxDate).getFullYear();
 
-      if (lastViewedMonth > 12) {
-        lastViewedMonth -= 12;
-      }
-
-      if (lastViewedMonth === maxMonth) {
-        this.showNextMonthBtn = false;
-      } else {
+      if (maxYear > this.year) {
         this.showNextMonthBtn = true;
+      } else {
+        let lastViewedMonth = this.month + this.numCalendars - 1;
+
+        if (lastViewedMonth > 12) {
+          lastViewedMonth -= 12;
+        }
+
+        if (lastViewedMonth === maxMonth) {
+          this.showNextMonthBtn = false;
+        } else {
+          this.showNextMonthBtn = true;
+        }
       }
     }
   }


### PR DESCRIPTION
…#157

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #157

## Summary:

The maxDate handling for the "show next month" button was not taking into consideration the year. This was causing the button to hide when viewing the same month regardless of year (e.g. viewing sept. 2023 when max date in sept. 2024).

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
