### PR TITLE
fix(minDate/maxDate): datepicker calendar month nav bug

### DIFF
--- a/src/auro-calendar.js
+++ b/src/auro-calendar.js
@@ -184,8 +184,15 @@ export class AuroCalendar extends RangeDatepicker {
   }
 
   updated(changedProperties) {
-    if (changedProperties.has('month') || changedProperties.has('year')) {
-      this.monthChanged(this.month, this.year);
+    if (
+      changedProperties.has("minDate") ||
+      changedProperties.has("maxDate") ||
+      changedProperties.has("month") ||
+      changedProperties.has("year")
+    ) {
+      if (changedProperties.has("month") || changedProperties.has("year")) {
+        this.monthChanged(this.month, this.year);
+      }
       this.assessNavigationButtonVisibility();
     }
     if (changedProperties.has('noRange')) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

This fixes a bug caused by changes to minDate and maxDate not invalidating whether the buttons for previous and next month appear (as happens for changes to the selected date). assessNavigationButtonVisibility() depends on all of minDate, maxDate, month, and year, and so changes to any of them should trigger rechecking the logic. 

## Summary:

Calls auro-calendar's assessNavigationButtonVisibility() when minDate or maxDate appear in changedProperties.
Tested on demo site by setting minDate/maxDate at the DevTools console like this:

$("auro-datepicker").minDate = "12/01/2023"

## Type of change:

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update
