### PR TITLE
Jbaker/refactor viewable month range

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "plusplus",
+        "Renderable"
+    ]
+}

--- a/apiExamples/calendarFocusDate.html
+++ b/apiExamples/calendarFocusDate.html
@@ -1,0 +1,4 @@
+<auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="12/01/2023" calendarFocusDate="11/01/2022">
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
+</auro-datepicker>

--- a/apiExamples/calendarStartAndEndDate.html
+++ b/apiExamples/calendarStartAndEndDate.html
@@ -1,0 +1,4 @@
+<auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="06/01/2022">
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
+</auro-datepicker>

--- a/demo/api.md
+++ b/demo/api.md
@@ -73,7 +73,7 @@
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/basic.html) -->
   <!-- The below content is automatically added from ./../../apiExamples/basic.html -->
-  <auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
+  <auro-datepicker>
     <span slot="fromLabel">Choose a date</span>
     <span slot="mobileDateLabel">Choose a date</span>
   </auro-datepicker>
@@ -85,7 +85,7 @@
 <!-- The below code snippet is automatically added from ./../../apiExamples/basic.html -->
 
 ```html
-<auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
+<auro-datepicker>
   <span slot="fromLabel">Choose a date</span>
   <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>
@@ -658,7 +658,7 @@ Sets the label used for the input. When the `range` attribute is used this is th
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/basic.html) -->
   <!-- The below content is automatically added from ./../../apiExamples/basic.html -->
-  <auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
+  <auro-datepicker>
     <span slot="fromLabel">Choose a date</span>
     <span slot="mobileDateLabel">Choose a date</span>
   </auro-datepicker>
@@ -670,7 +670,7 @@ Sets the label used for the input. When the `range` attribute is used this is th
 <!-- The below code snippet is automatically added from ./../../apiExamples/basic.html -->
 
 ```html
-<auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
+<auro-datepicker>
   <span slot="fromLabel">Choose a date</span>
   <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>
@@ -712,7 +712,7 @@ Sets the label used for the selected date display at the top of the bib when vie
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/basic.html) -->
   <!-- The below content is automatically added from ./../../apiExamples/basic.html -->
-  <auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
+  <auro-datepicker>
     <span slot="fromLabel">Choose a date</span>
     <span slot="mobileDateLabel">Choose a date</span>
   </auro-datepicker>
@@ -724,7 +724,7 @@ Sets the label used for the selected date display at the top of the bib when vie
 <!-- The below code snippet is automatically added from ./../../apiExamples/basic.html -->
 
 ```html
-<auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
+<auro-datepicker>
   <span slot="fromLabel">Choose a date</span>
   <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>

--- a/demo/api.md
+++ b/demo/api.md
@@ -7,7 +7,9 @@
 
 | Property                          | Attribute                         | Type      | Default                                          | Description                                      |
 |-----------------------------------|-----------------------------------|-----------|--------------------------------------------------|--------------------------------------------------|
-| [centralDate](#centralDate)                     | `centralDate`                     | `String`  |                                                  | The date that determines the currently visible month. |
+| [calendarEndDate](#calendarEndDate)                 | `calendarEndDate`                 | `array`   | "undefined"                                      |                                                  |
+| [calendarFocusDate](#calendarFocusDate)               | `calendarFocusDate`               | `string`  | "value"                                          |                                                  |
+| [calendarStartDate](#calendarStartDate)               | `calendarStartDate`               | `array`   | "undefined"                                      |                                                  |
 | [disabled](#disabled)                        | `disabled`                        | `Boolean` | false                                            | If set, disables the datepicker.                 |
 | [error](#error)                           | `error`                           | `String`  |                                                  | When defined, sets persistent validity to `customError` and sets `setCustomValidity` = attribute value. |
 | [maxDate](#maxDate)                         | `maxDate`                         | `String`  |                                                  | Maximum date. All dates after will be disabled.  |
@@ -71,7 +73,7 @@
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/basic.html) -->
   <!-- The below content is automatically added from ./../../apiExamples/basic.html -->
-  <auro-datepicker>
+  <auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
     <span slot="fromLabel">Choose a date</span>
     <span slot="mobileDateLabel">Choose a date</span>
   </auro-datepicker>
@@ -83,7 +85,7 @@
 <!-- The below code snippet is automatically added from ./../../apiExamples/basic.html -->
 
 ```html
-<auro-datepicker>
+<auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
   <span slot="fromLabel">Choose a date</span>
   <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>
@@ -656,7 +658,7 @@ Sets the label used for the input. When the `range` attribute is used this is th
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/basic.html) -->
   <!-- The below content is automatically added from ./../../apiExamples/basic.html -->
-  <auro-datepicker>
+  <auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
     <span slot="fromLabel">Choose a date</span>
     <span slot="mobileDateLabel">Choose a date</span>
   </auro-datepicker>
@@ -668,7 +670,7 @@ Sets the label used for the input. When the `range` attribute is used this is th
 <!-- The below code snippet is automatically added from ./../../apiExamples/basic.html -->
 
 ```html
-<auro-datepicker>
+<auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
   <span slot="fromLabel">Choose a date</span>
   <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>
@@ -710,7 +712,7 @@ Sets the label used for the selected date display at the top of the bib when vie
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/basic.html) -->
   <!-- The below content is automatically added from ./../../apiExamples/basic.html -->
-  <auro-datepicker>
+  <auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
     <span slot="fromLabel">Choose a date</span>
     <span slot="mobileDateLabel">Choose a date</span>
   </auro-datepicker>
@@ -722,7 +724,7 @@ Sets the label used for the selected date display at the top of the bib when vie
 <!-- The below code snippet is automatically added from ./../../apiExamples/basic.html -->
 
 ```html
-<auro-datepicker>
+<auro-datepicker range calendarStartDate="01/11/2024" calendarEndDate="11/01/2024" minDate="02/12/2024" maxDate="09/20/2024" centralDate="07/20/2024" value="06/20/2024" valueEnd="09/04/2024">
   <span slot="fromLabel">Choose a date</span>
   <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>

--- a/demo/api.md
+++ b/demo/api.md
@@ -7,9 +7,9 @@
 
 | Property                          | Attribute                         | Type      | Default                                          | Description                                      |
 |-----------------------------------|-----------------------------------|-----------|--------------------------------------------------|--------------------------------------------------|
-| [calendarEndDate](#calendarEndDate)                 | `calendarEndDate`                 | `array`   | "undefined"                                      |                                                  |
-| [calendarFocusDate](#calendarFocusDate)               | `calendarFocusDate`               | `string`  | "value"                                          |                                                  |
-| [calendarStartDate](#calendarStartDate)               | `calendarStartDate`               | `array`   | "undefined"                                      |                                                  |
+| [calendarEndDate](#calendarEndDate)                 | `calendarEndDate`                 | `String`  | "undefined"                                      | The last date that may be displayed in the calendar |
+| [calendarFocusDate](#calendarFocusDate)               | `calendarFocusDate`               | `String`  | "value"                                          | The date that will first be visually rendered to the user in the calendar. |
+| [calendarStartDate](#calendarStartDate)               | `calendarStartDate`               | `String`  | "undefined"                                      | The first date that may be displayed in the calendar. |
 | [disabled](#disabled)                        | `disabled`                        | `Boolean` | false                                            | If set, disables the datepicker.                 |
 | [error](#error)                           | `error`                           | `String`  |                                                  | When defined, sets persistent validity to `customError` and sets `setCustomValidity` = attribute value. |
 | [maxDate](#maxDate)                         | `maxDate`                         | `String`  |                                                  | Maximum date. All dates after will be disabled.  |
@@ -21,7 +21,7 @@
 | [setCustomValidity](#setCustomValidity)               | `setCustomValidity`               | `String`  |                                                  | Sets a custom help text message to display for all validityStates. |
 | [setCustomValidityRangeOverflow](#setCustomValidityRangeOverflow)  | `setCustomValidityRangeOverflow`  | `String`  |                                                  | Custom help text message to display when validity = `rangeOverflow`. |
 | [setCustomValidityRangeUnderflow](#setCustomValidityRangeUnderflow) | `setCustomValidityRangeUnderflow` | `String`  |                                                  | Custom help text message to display when validity = `rangeUnderflow`. |
-| [setCustomValidityValueMissing](#setCustomValidityValueMissing)   | `setCustomValidityValueMissing`   | `String`  |                                                  | Help text message to display when validity = `valueMissing`; |
+| [setCustomValidityValueMissing](#setCustomValidityValueMissing)   | `setCustomValidityValueMissing`   | `String`  |                                                  | Help text message to display when validity = `valueMissing`. |
 | [validity](#validity)                        | `validity`                        | `String`  | "undefined"                                      | Specifies the `validityState` this element is in. |
 | [value](#value)                           | `value`                           | `String`  | "undefined"                                      | Value selected for the date picker.              |
 | [valueEnd](#valueEnd)                        | `valueEnd`                        | `String`  | "undefined"                                      | Value selected for the second date picker when using date range. |
@@ -95,26 +95,67 @@
 
 ### Property Examples
 
-#### centralDate
+#### calendarStartDate & calendarEndDate
 
-Date that determines the currently visible month.
+The `calendarStartDate` and `calendarEndDate` properties may be used to explicitly control which calendar months _may_ be rendered in the calendar.
+
+In <strong>desktop</strong>, the calendar month navigation will be restricted by these dates. In <strong>mobile</strong>, the following logic is used:
+
+- if both `calendarStartDate` and `calendarEndDate` are defined: all months between, including these dates, will be rendered.
+- If only `calendarStartDate` is defined: 12 months will be rendered starting with this value.
+- if only `calendarEndDate` is defined: The current date month through the value of this property will be rendered.
+
+Note: This does not restrict setting a value outside of those date constraints. These properties _only_ define which months can be rendered in the calendar. A user may still type any date into the input field. If actual value selection restrictions are needed, see the `minDate` and `maxDate` properties which may be used standalone, or in conjunction with `calendarStartDate` and `calendarEndDate`.
 
 <div class="exampleWrapper">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/centralDate.html) -->
-  <!-- The below content is automatically added from ./../../apiExamples/centralDate.html -->
-  <auro-datepicker centralDate="06/16/1980">
-    <span slot="label">Choose a date</span>
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/calendarFocusDate.html) -->
+  <!-- The below content is automatically added from ./../../apiExamples/calendarFocusDate.html -->
+  <auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="12/01/2023" calendarFocusDate="11/01/2022">
+    <span slot="fromLabel">Choose a date</span>
+    <span slot="mobileDateLabel">Choose a date</span>
   </auro-datepicker>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../../apiExamples/centralDate.html) -->
-<!-- The below code snippet is automatically added from ./../../apiExamples/centralDate.html -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../../apiExamples/calendarFocusDate.html) -->
+<!-- The below code snippet is automatically added from ./../../apiExamples/calendarFocusDate.html -->
 
 ```html
-<auro-datepicker centralDate="06/16/1980">
-  <span slot="label">Choose a date</span>
+<auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="12/01/2023" calendarFocusDate="11/01/2022">
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
+</auro-datepicker>
+```
+<!-- AURO-GENERATED-CONTENT:END -->
+</auro-accordion>
+
+#### calendarFocusDate
+
+The `calendarFocusDate` controls which calendar month is first presented to the user when they open the dropdown bib.
+
+In <strong>desktop</strong> layout, the first month actually rendered will be the `calendarFocusDate` if defined. Once the user manually navigates the calendar to a different month, the calendar view will remain where the user left off when they close and reopen the bib. If the `calendarFocusDate` property is changed, this will re-render the calendar starting at the new date. If `calendarFocusDate` is undefined, the first rendered month will be the current date or the first renderable date defined by `calendarStartDate`.
+
+In <strong>mobile</strong> layout, upon first opening the bib, the vertical list of months will scroll (with no animation) to the month defined by the `calendarFocusDate`. If the user scrolls the list to a different position, the scroll position will remain where the user left off when they close and reopen the bib. If the `calendarFocusDate` is changed, the list will scroll to the new dates month. If `calendarFocusDate` is undefined, the list will start at the top most scroll position.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/calendarFocusDate.html) -->
+  <!-- The below content is automatically added from ./../../apiExamples/calendarFocusDate.html -->
+  <auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="12/01/2023" calendarFocusDate="11/01/2022">
+    <span slot="fromLabel">Choose a date</span>
+    <span slot="mobileDateLabel">Choose a date</span>
+  </auro-datepicker>
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../../apiExamples/calendarFocusDate.html) -->
+<!-- The below code snippet is automatically added from ./../../apiExamples/calendarFocusDate.html -->
+
+```html
+<auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="12/01/2023" calendarFocusDate="11/01/2022">
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,9 +4,9 @@
 
 | Property                          | Attribute                         | Type      | Default                                          | Description                                      |
 |-----------------------------------|-----------------------------------|-----------|--------------------------------------------------|--------------------------------------------------|
-| `calendarEndDate`                 | `calendarEndDate`                 | `array`   | "undefined"                                      |                                                  |
-| `calendarFocusDate`               | `calendarFocusDate`               | `string`  | "value"                                          |                                                  |
-| `calendarStartDate`               | `calendarStartDate`               | `array`   | "undefined"                                      |                                                  |
+| `calendarEndDate`                 | `calendarEndDate`                 | `String`  | "undefined"                                      | The last date that may be displayed in the calendar |
+| `calendarFocusDate`               | `calendarFocusDate`               | `String`  | "value"                                          | The date that will first be visually rendered to the user in the calendar. |
+| `calendarStartDate`               | `calendarStartDate`               | `String`  | "undefined"                                      | The first date that may be displayed in the calendar. |
 | `disabled`                        | `disabled`                        | `Boolean` | false                                            | If set, disables the datepicker.                 |
 | `error`                           | `error`                           | `String`  |                                                  | When defined, sets persistent validity to `customError` and sets `setCustomValidity` = attribute value. |
 | `maxDate`                         | `maxDate`                         | `String`  |                                                  | Maximum date. All dates after will be disabled.  |
@@ -18,7 +18,7 @@
 | `setCustomValidity`               | `setCustomValidity`               | `String`  |                                                  | Sets a custom help text message to display for all validityStates. |
 | `setCustomValidityRangeOverflow`  | `setCustomValidityRangeOverflow`  | `String`  |                                                  | Custom help text message to display when validity = `rangeOverflow`. |
 | `setCustomValidityRangeUnderflow` | `setCustomValidityRangeUnderflow` | `String`  |                                                  | Custom help text message to display when validity = `rangeUnderflow`. |
-| `setCustomValidityValueMissing`   | `setCustomValidityValueMissing`   | `String`  |                                                  | Help text message to display when validity = `valueMissing`; |
+| `setCustomValidityValueMissing`   | `setCustomValidityValueMissing`   | `String`  |                                                  | Help text message to display when validity = `valueMissing`. |
 | `validity`                        | `validity`                        | `String`  | "undefined"                                      | Specifies the `validityState` this element is in. |
 | `value`                           | `value`                           | `String`  | "undefined"                                      | Value selected for the date picker.              |
 | `valueEnd`                        | `valueEnd`                        | `String`  | "undefined"                                      | Value selected for the second date picker when using date range. |

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,9 @@
 
 | Property                          | Attribute                         | Type      | Default                                          | Description                                      |
 |-----------------------------------|-----------------------------------|-----------|--------------------------------------------------|--------------------------------------------------|
-| `centralDate`                     | `centralDate`                     | `String`  |                                                  | The date that determines the currently visible month. |
+| `calendarEndDate`                 | `calendarEndDate`                 | `array`   | "undefined"                                      |                                                  |
+| `calendarFocusDate`               | `calendarFocusDate`               | `string`  | "value"                                          |                                                  |
+| `calendarStartDate`               | `calendarStartDate`               | `array`   | "undefined"                                      |                                                  |
 | `disabled`                        | `disabled`                        | `Boolean` | false                                            | If set, disables the datepicker.                 |
 | `error`                           | `error`                           | `String`  |                                                  | When defined, sets persistent validity to `customError` and sets `setCustomValidity` = attribute value. |
 | `maxDate`                         | `maxDate`                         | `String`  |                                                  | Maximum date. All dates after will be disabled.  |

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -20,18 +20,46 @@
 
 ### Property Examples
 
-#### centralDate
+#### calendarStartDate & calendarEndDate
 
-Date that determines the currently visible month.
+The `calendarStartDate` and `calendarEndDate` properties may be used to explicitly control which calendar months _may_ be rendered in the calendar.
+
+In <strong>desktop</strong>, the calendar month navigation will be restricted by these dates. In <strong>mobile</strong>, the following logic is used:
+
+- if both `calendarStartDate` and `calendarEndDate` are defined: all months between, including these dates, will be rendered.
+- If only `calendarStartDate` is defined: 12 months will be rendered starting with this value.
+- if only `calendarEndDate` is defined: The current date month through the value of this property will be rendered.
+
+Note: This does not restrict setting a value outside of those date constraints. These properties _only_ define which months can be rendered in the calendar. A user may still type any date into the input field. If actual value selection restrictions are needed, see the `minDate` and `maxDate` properties which may be used standalone, or in conjunction with `calendarStartDate` and `calendarEndDate`.
 
 <div class="exampleWrapper">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/centralDate.html) -->
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/calendarFocusDate.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../../apiExamples/centralDate.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../../apiExamples/calendarFocusDate.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
+#### calendarFocusDate
+
+The `calendarFocusDate` controls which calendar month is first presented to the user when they open the dropdown bib.
+
+In <strong>desktop</strong> layout, the first month actually rendered will be the `calendarFocusDate` if defined. Once the user manually navigates the calendar to a different month, the calendar view will remain where the user left off when they close and reopen the bib. If the `calendarFocusDate` property is changed, this will re-render the calendar starting at the new date. If `calendarFocusDate` is undefined, the first rendered month will be the current date or the first renderable date defined by `calendarStartDate`.
+
+In <strong>mobile</strong> layout, upon first opening the bib, the vertical list of months will scroll (with no animation) to the month defined by the `calendarFocusDate`. If the user scrolls the list to a different position, the scroll position will remain where the user left off when they close and reopen the bib. If the `calendarFocusDate` is changed, the list will scroll to the new dates month. If `calendarFocusDate` is undefined, the list will start at the top most scroll position.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/calendarFocusDate.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../../apiExamples/calendarFocusDate.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/src/auro-calendar-cell.js
+++ b/src/auro-calendar-cell.js
@@ -300,9 +300,11 @@ export class AuroCalendarCell extends LitElement {
   firstUpdated() {
     this.datepicker = this.runtimeUtils.closestElement('auro-datepicker', this);
 
-    this.datepicker.addEventListener('auroDatePicker-toggled', () => {
-      this.handleSlotContent();
-    });
+    if (this.datepicker) {
+      this.datepicker.addEventListener('auroDatePicker-toggled', () => {
+        this.handleSlotContent();
+      });
+    }
 
     this.calendarMonth = this.runtimeUtils.closestElement('auro-calendar-month', this);
     this.auroPopover = this.shadowRoot.querySelector('auro-popover');

--- a/src/auro-calendar-month.js
+++ b/src/auro-calendar-month.js
@@ -86,12 +86,6 @@ export class AuroCalendarMonth extends RangeDatepickerCalendar {
     `;
   }
 
-  updated(changedProperties) {
-    if (changedProperties.has('year') || changedProperties.has('month')) {
-      this.yearAndMonthChanged(this.year, this.month);
-    }
-  }
-
   /* Disabling linter for render as this code is directly from range-datepicker-calendar */
   /* eslint-disable */
   render() {

--- a/src/auro-calendar.js
+++ b/src/auro-calendar.js
@@ -203,6 +203,15 @@ export class AuroCalendar extends RangeDatepicker {
     return renderedHtml;
   }
 
+  /**
+   * Request the calendar be scrolled to a given date.
+   * @param {String} date - The date to scroll into view.
+   * @returns {void}
+   */
+  scrollMonthIntoView(date) {
+    this.utilCal.scrollMonthIntoView(this, date);
+  }
+
   firstUpdated() {
     this.addEventListener('date-from-changed', () => {
       this.dispatchEvent(new CustomEvent('auroCalendar-dateSelected', {

--- a/src/auro-calendar.js
+++ b/src/auro-calendar.js
@@ -59,7 +59,6 @@ export class AuroCalendar extends RangeDatepicker {
     this.utilCalRender = new UtilitiesCalendarRender();
 
     this.datepicker = this.runtimeUtils.closestElement('auro-datepicker', this);
-
     this.calendarStartDate = undefined;
     this.calendarEndDate = undefined;
     this.centralDate = undefined;
@@ -185,19 +184,37 @@ export class AuroCalendar extends RangeDatepicker {
       this.firstRenderedMonth = this.firstMonthRenderable;
     }
 
-    // Loop through the number of calendars to render and add the HTML
-    for (let cal = 0; cal < this.numCalendars; cal += 1) {
-      const date = this.firstRenderedMonth;
-      const newMonthDate = new Date(date.setMonth(date.getMonth() + 1));
+    // Add the first calendar to the HTML
+    const firstMonth = this.firstRenderedMonth.getMonth() + 1;
+    const firstYear = this.firstRenderedMonth.getFullYear();
 
-      const year = newMonthDate.getFullYear();
-      let month = newMonthDate.getMonth();
+    renderedHtml = html`${renderedHtml}${this.utilCalRender.renderCalendar(this, firstMonth, firstYear)}`;
 
-      if (month === 0) {
-        month = 12;
+    // Loop through the number of remaining calendars to render and add the HTML
+    let newMonthDate = undefined;
+
+    for (let cal = 0; cal < this.numCalendars - 1; cal += 1) {
+
+      const date = newMonthDate || this.firstRenderedMonth;
+
+      const oldMonth = date.getMonth() + 1;
+      const oldYear = date.getFullYear();
+
+      let newMonth = undefined;
+      let newYear = undefined;
+
+      if (oldMonth === 12) {
+        newMonth = 1;
+        newYear = oldYear + 1;
+      } else {
+        newMonth = oldMonth + 1;
+        newYear = oldYear;
       }
 
-      renderedHtml = html`${renderedHtml}${this.utilCalRender.renderCalendar(this, month, year)}`;
+      const newMonthDateStr = `${newMonth}/1/${newYear}`;
+      newMonthDate = new Date(newMonthDateStr);
+
+      renderedHtml = html`${renderedHtml}${this.utilCalRender.renderCalendar(this, newMonth, newYear)}`;
     }
 
     return renderedHtml;

--- a/src/auro-datepicker.js
+++ b/src/auro-datepicker.js
@@ -106,7 +106,7 @@ export class AuroDatePicker extends LitElement {
     /**
      * @private
      */
-    this.centralDate = new Date();
+    this.centralDate = this.getAttribute('calendarStartDate') || new Date();
 
     /**
      * @private

--- a/src/auro-datepicker.js
+++ b/src/auro-datepicker.js
@@ -39,7 +39,7 @@ import inputVersion from './inputVersion';
  * @attr {String} setCustomValidityValueMissing - Help text message to display when validity = `valueMissing`.
  * @attr {String} calendarStartDate - The first date that may be displayed in the calendar.
  * @attr {String} calendarEndDate - The last date that may be displayed in the calendar
- * @attr {String} calendarFocusDate - The date that may be visually rendered to the user in the calendar.
+ * @attr {String} calendarFocusDate - The date that will first be visually rendered to the user in the calendar.
  * @attr {Boolean} disabled - If set, disables the datepicker.
  * @attr {Boolean} noValidate - If set, disables auto-validation on blur.
  * @attr {Boolean} required - Populates the `required` attribute on the input. Used for client-side validation.

--- a/src/auro-datepicker.js
+++ b/src/auro-datepicker.js
@@ -119,6 +119,11 @@ export class AuroDatePicker extends LitElement {
     this.dateSlotContent = [];
 
     /**
+     * @private
+     */
+    this.forceScrollOnNextMobileCalendarRender = false;
+
+    /**
      * Generate unique names for dependency components.
      */
     const versioning = new AuroDependencyVersioning();
@@ -244,6 +249,8 @@ export class AuroDatePicker extends LitElement {
   handleFocusDateChange() {
     if (this.calendarFocusDate) {
       this.centralDate = this.calendarFocusDate;
+
+      this.forceScrollOnNextMobileCalendarRender = true;
     }
   }
 
@@ -469,6 +476,13 @@ export class AuroDatePicker extends LitElement {
     this.dropdown.addEventListener('auroDropdown-toggled', () => {
       this.setAttribute('aria-expanded', this.dropdown.isPopoverVisible);
       this.notifyDatepickerToggled();
+
+      if (this.dropdown.getAttribute('data-show')) {
+        if (this.forceScrollOnNextMobileCalendarRender) {
+          this.calendar.scrollMonthIntoView(this.calendarFocusDate);
+          this.forceScrollOnNextMobileCalendarRender = false;
+        }
+      }
     });
 
     if (!this.dropdown.hasAttribute('aria-expanded')) {

--- a/src/style-auro-calendar-month.scss
+++ b/src/style-auro-calendar-month.scss
@@ -18,9 +18,9 @@ $calendar-padding-desktop: var(--ds-size-200, $ds-size-200);
   position: relative;
 
   display: block;
-  width: calc(100% - var(--ds-size-300, $ds-size-300));
+  width: calc(100% - var(--ds-size-200, $ds-size-200) - var(--ds-size-200, $ds-size-200));
 
-  padding: 0 var(--ds-size-200, $ds-size-200);
+  margin: 0 var(--ds-size-200, $ds-size-200);
 
   background-color: var(--ds-color-background-lightest, $ds-color-background-lightest);
 
@@ -28,14 +28,6 @@ $calendar-padding-desktop: var(--ds-size-200, $ds-size-200);
     width: $calendar-width;
 
     padding: $calendar-padding-desktop;
-  }
-}
-
-:host(:last-of-type) {
-  margin-bottom: 150px; // This value is derived from the height of the mobile-footer
-
-  @include auro_grid-breakpoint--sm {
-    margin-bottom: 0;
   }
 }
 

--- a/src/style-auro-calendar.scss
+++ b/src/style-auro-calendar.scss
@@ -56,10 +56,6 @@
 }
 
 .mobileHeader {
-  position: absolute;
-  top: 0;
-  left: 0;
-
   display: none;
   width: 100%;
   height: var(--mobile-header-height);
@@ -122,9 +118,6 @@
 }
 
 .mobileFooter {
-  position: fixed;
-  bottom: 0;
-
   display: none;
   width: 100%;
 
@@ -168,16 +161,21 @@
     display: flex;
   }
 
-  .calendars {
-    position: relative;
-    top: var(--mobile-header-height);
+  .calendarWrapper {
+    display: flex;
+    height: 100%;
 
+    flex-direction: column;
+    overflow: auto hidden;
+  }
+
+  .calendars {
     display: flex;
     flex-direction: column;
+    flex: 1;
 
     align-items: center;
     width: 100%;
-    height: calc(100vh - var(--mobile-header-height));
 
     overflow-y: scroll;
     overscroll-behavior: contain;

--- a/src/style-auro-calendar.scss
+++ b/src/style-auro-calendar.scss
@@ -59,6 +59,7 @@
   display: none;
   width: 100%;
   height: var(--mobile-header-height);
+  z-index: +1;
 
   align-items: center;
   flex-direction: row;

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,0 +1,71 @@
+export class AuroDatepickerUtilities {
+
+  /**
+   * Converts any date object to a date object representing the first day of the month.
+   * @param {Object} date - Date to convert to the first day of the month.
+   * @returns {Object} Returns the auro-calendar-months HTML.
+   */
+  convertDateToFirstOfMonth(date) {
+    const dateObj = new Date(date);
+
+    return new Date(dateObj.getFullYear(), dateObj.getMonth(), 1);
+  }
+
+  /**
+   * Calculate the number of months between two dates.
+   * @param {Object} date1 - First date to compare.
+   * @param {Object} date2 - Second date to compare.
+   * @returns {Number} Returns the number of months between the two dates.
+   */
+  monthDiff(date1, date2) {
+    let months = 0;
+    months = (date2.getFullYear() - date1.getFullYear()) * 12; // eslint-disable-line no-magic-numbers
+    months -= date1.getMonth();
+    months += date2.getMonth();
+    months += 1;
+
+    return months <= 0 ? 0 : months;
+  }
+
+  /**
+   * Convert a date object to string format.
+   * @private
+   * @param {Object} date - Date to convert to string.
+   * @returns {Object} Returns the date as a string.
+   */
+  getDateAsString(date) {
+    const year = new Date(date).getFullYear();
+    const month = new Date(date).getMonth() + 1;
+    const day = new Date(date).getDate();
+
+    const dateStr = `${month}/${day}/${year}`;
+
+    return dateStr;
+  }
+
+  /**
+   * Function to generate checkmark svg.
+   * @private
+   * @param {Object} icon - Icon object containing the SVG.
+   * @returns {Object} Returns the svg portion of the icon object.
+   */
+  generateIconHtml(icon) {
+    this.dom = new DOMParser().parseFromString(icon.svg, 'text/html');
+    this.svg = this.dom.body.firstChild;
+
+    return this.svg;
+  }
+
+  /**
+   * Compares two dates to see if they match.
+   * @private
+   * @param {Object} date1 - First date to compare.
+   * @param {Object} date2 - Second date to compare.
+   * @returns {Boolean} Returns true if the dates match.
+   */
+  datesMatch(date1, date2) {
+    const match = new Date(date1).getTime() === new Date(date2).getTime();
+
+    return match;
+  }
+}

--- a/src/utilitiesCalendar.js
+++ b/src/utilitiesCalendar.js
@@ -5,6 +5,22 @@ export class CalendarUtilities {
     this.util = new AuroDatepickerUtilities();
   }
 
+
+  /**
+   * Scroll the calendar month list to a given date.
+   * @param {Object} elem - The calendar element.
+   * @param {String} date - The date to scroll into view.
+   * @returns {void}
+   */
+  scrollMonthIntoView(elem, date) {
+    const month = new Date(date).getMonth() + 1;
+    const year = new Date(date).getFullYear();
+    const selector = `#month-${month}-${year}`;
+    const monthElem = elem.shadowRoot.querySelector(selector);
+
+    monthElem.scrollIntoView();
+  }
+
   /**
    * Sends an event requesting the dropdown bib be closed.
    * @private

--- a/src/utilitiesCalendar.js
+++ b/src/utilitiesCalendar.js
@@ -1,0 +1,120 @@
+import { AuroDatepickerUtilities } from './utilities';
+
+export class CalendarUtilities {
+  constructor() {
+    this.util = new AuroDatepickerUtilities();
+  }
+
+  /**
+   * Sends an event requesting the dropdown bib be closed.
+   * @private
+   * @returns {void}
+   */
+  requestDismiss() {
+    this.dispatchEvent(new CustomEvent('auroCalendar-dismissRequest', {
+      bubbles: true,
+      cancelable: false,
+      composed: true,
+    }));
+  }
+
+  /**
+   * Handles the visibility of the previous and next month buttons.
+   * @private
+   * @param {Object} elem - The auro-calendar element.
+   * @returns {void}
+   */
+  assessNavigationButtonVisibility(elem) {
+
+    /**
+     * Hide/show the previous month button.
+     */
+
+    // 1. Compare the first rendered month to the earliest renderable month to determine if the previous month button should be hidden or shown
+    if (!elem.hasAttribute('calendarStartDate') && !elem.hasAttribute('minDate')) {
+      elem.showPrevMonthBtn = true;
+    } else if (this.util.convertDateToFirstOfMonth(new Date(elem.centralDate)) <= elem.firstMonthRenderable) {
+      elem.showPrevMonthBtn = false;
+    } else {
+      elem.showPrevMonthBtn = true;
+    }
+
+    /**
+     * Hide/show the next month button.
+     */
+
+    // 1. Determine the last month that can possibly be rendered into the DOM.
+    let lastRenderableMonth = undefined; // eslint-disable-line no-undef-init
+
+    if (elem.hasAttribute('calendarEndDate')) {
+      lastRenderableMonth = new Date(elem.getAttribute('calendarEndDate'));
+    } else if (elem.hasAttribute('maxDate')) {
+      lastRenderableMonth = new Date(elem.getAttribute('maxDate'));
+    }
+
+    if (lastRenderableMonth) {
+      lastRenderableMonth = this.util.convertDateToFirstOfMonth(lastRenderableMonth);
+    }
+
+    // 2. Determine the last month currently rendered into the DOM.
+    let lastRenderedMonth = new Date(elem.centralDate);
+
+    if (!elem.noRange) {
+      lastRenderedMonth = new Date(lastRenderedMonth.setMonth(lastRenderedMonth.getMonth() + 1));
+    }
+
+    lastRenderedMonth = this.util.convertDateToFirstOfMonth(lastRenderedMonth);
+
+    // 3. Compare the two and choose to show or hide the next month button
+    if (lastRenderedMonth >= lastRenderableMonth) {
+      elem.showNextMonthBtn = false;
+    } else {
+      elem.showNextMonthBtn = true;
+    }
+
+    // Request an update to the component needed to actually show/hide the buttons in the DOM
+    elem.requestUpdate();
+  }
+
+  /**
+   * Handles the change of the centralDate property.
+   * @param {Object} elem - The auro-calendar element.
+   * @private
+   * @returns {void}
+   */
+  centralDateChanged(elem) {
+    this.assessNavigationButtonVisibility(elem);
+
+    elem.dispatchEvent(new CustomEvent('auroCalendar-centralDateChanged', {
+      detail: {
+        bubbles: true,
+        cancelable: false,
+        composed: true,
+        date: elem.centralDate
+      }
+    }));
+  }
+
+  /**
+   * Updates the month and year when the user navigates to a different calendar month.
+   * @param {Object} elem - The auro-calendar element.
+   * @param {String} direction - The direction the user is navigating.
+   * @returns {void}
+   */
+  handleMonthChange(elem, direction) {
+    // Determine if the month number is going to be incremented or decremented
+    let increment = 0;
+
+    if (direction === 'next') {
+      increment = 1;
+    } else if (direction === 'prev') {
+      increment = -1; // eslint-disable-line no-magic-numbers
+    }
+
+    // calculate the new central date
+    const newCentralDate = new Date(elem.centralDate).setMonth(new Date(elem.centralDate).getMonth() + increment);
+
+    // set the new central date to the first day of the month
+    elem.centralDate = this.util.convertDateToFirstOfMonth(newCentralDate);
+  }
+}

--- a/src/utilitiesCalendarRender.js
+++ b/src/utilitiesCalendarRender.js
@@ -1,0 +1,139 @@
+import { html } from 'lit';
+import { AuroDatepickerUtilities } from './utilities';
+
+export class UtilitiesCalendarRender {
+  constructor() {
+    this.util = new AuroDatepickerUtilities();
+  }
+
+  /**
+   * Determine how many months to render based on the defined calendar range.
+   * @param {Object} elem - The auro-calendar element.
+   * @private
+   * @returns {Number} Returns the number of months between the calendarStartDate and the calendarEndDate.
+   */
+  determineDefinedCalendarRange(elem) {
+    if (elem.getAttribute('calendarStartDate') && elem.getAttribute('calendarEndDate')) {
+      // if we have a defined range of months, use that
+      elem.calendarRangeMonths = elem.util.monthDiff(new Date(elem.getAttribute('calendarStartDate')), new Date(elem.getAttribute('calendarEndDate')));
+    } else {
+      // if we don't have a defined range of months, use undefined
+      elem.calendarRangeMonths = undefined;
+    }
+
+    return elem.calendarRangeMonths;
+  }
+
+  /**
+   * Determines how many calendar months can be rendered based on the screen size and defined range.
+   * @param {Object} elem - The auro-calendar element.
+   * @private
+   * @returns {Number} Returns the maximum number of months that can be rendered.
+   */
+  maximumRenderableMonths(elem) {
+    const definedRangeMonths = this.determineDefinedCalendarRange(elem);
+
+    // number of calendars that could be rendered at a time
+    let numCalendars = 1;
+
+    // range supported calendars use two viewable months in desktop view
+    if (!elem.noRange) {
+      numCalendars = 2; // eslint-disable-line no-magic-numbers
+    }
+
+    // change the max calendar number when viewed on mobile
+    if (window.innerWidth < elem.mobileBreakpoint) {
+      // use definedRangeMonths if we have it otherwise default to 12
+      numCalendars = definedRangeMonths || 12; // eslint-disable-line no-magic-numbers
+    }
+
+    // If we have a defined range of months and it's less than the numCalendars, use the defined range.
+    // This covers the scenario where the datepicker has "range" but the available months are less than 2.
+    if (definedRangeMonths && definedRangeMonths < numCalendars) {
+      numCalendars = definedRangeMonths;
+    }
+
+    return numCalendars;
+  }
+
+
+  /**
+   * Determines the number of months rendered inside the calendar.
+   * @param {Object} elem - The auro-calendar element.
+   * @private
+   * @returns {void}
+   */
+  determineNumCalendarsToRender(elem) {
+    // 1. Determine the maximum number of months that can be rendered.
+    //    This is based on the screen size and the defined range of months.
+    const maxRenderableMonths = this.maximumRenderableMonths(elem);
+
+    // 2. Start by assuming we can render the max number of months.
+    let calendarCount = maxRenderableMonths;
+
+    // 3. If we didn't get a count early, restrict based on min/max date.
+    if (!calendarCount && elem.minDate && elem.maxDate) {
+      const monthsInRange = this.util.monthDiff(new Date(elem.minDate), new Date(elem.maxDate));
+
+      if (monthsInRange < maxRenderableMonths) {
+        calendarCount = monthsInRange;
+      }
+    }
+
+    if (elem.numCalendars !== calendarCount) {
+      elem.numCalendars = calendarCount;
+      elem.requestUpdate();
+    }
+  }
+
+  /**
+   * Determine which month is to be rendered first.
+   * @param {Object} elem - The auro-calendar element.
+   * @private
+   * @returns {void}
+   */
+  setFirstRenderableMonthDate(elem) {
+    const start = elem.getAttribute('calendarStartDate');
+    const min = elem.getAttribute('minDate');
+
+    let firstMonthDate = new Date();
+
+    if (start) {
+      firstMonthDate = new Date(start);
+    } else if (min) {
+      firstMonthDate = new Date(min);
+    }
+
+    // sets to the first day of the month
+    elem.firstMonthRenderable = elem.util.convertDateToFirstOfMonth(firstMonthDate);
+  }
+
+  /**
+   * Renders one auro-calendar-month HTML for the given month/date combination.
+   * @private
+   * @param {Object} elem - The auro-calendar element.
+   * @param {Number} month - Month the calendar displays.
+   * @param {Number} year - Year the calendar displays.
+   * @returns {Object} Returns the auro-calendar-month HTML.
+   */
+  renderCalendar(elem, month, year) {
+    return html`
+      <auro-calendar-month
+        .disabledDays="${elem.disabledDays}"
+        min="${elem.min}"
+        max="${elem.max}"
+        ?noRange="${elem.noRange}"
+        .hoveredDate="${elem.hoveredDate}"
+        .dateTo="${elem.dateTo}"
+        .dateFrom="${elem.dateFrom}"
+        .locale="${elem.locale}"
+        month="${month}"
+        year="${year}"
+        @hovered-date-changed="${elem.hoveredDateChanged}"
+        @date-from-changed="${elem.dateFromChanged}"
+        @date-to-changed="${elem.dateToChanged}"
+      >
+      </auro-calendar-month>
+    `;
+  }
+}

--- a/src/utilitiesCalendarRender.js
+++ b/src/utilitiesCalendarRender.js
@@ -119,9 +119,10 @@ export class UtilitiesCalendarRender {
   renderCalendar(elem, month, year) {
     return html`
       <auro-calendar-month
+        id="${`month-${month}-${year}`}"
         .disabledDays="${elem.disabledDays}"
-        min="${elem.min}"
-        max="${elem.max}"
+        .min="${elem.min}"
+        .max="${elem.max}"
         ?noRange="${elem.noRange}"
         .hoveredDate="${elem.hoveredDate}"
         .dateTo="${elem.dateTo}"

--- a/test/auro-datepicker.test.js
+++ b/test/auro-datepicker.test.js
@@ -290,6 +290,8 @@ describe('auro-datepicker', () => {
       <auro-datepicker></auro-datepicker>
     `);
 
+    await elementUpdated(el);
+
     const calendar = el.shadowRoot.querySelector('auro-calendar');
     const calendarMonth = calendar.shadowRoot.querySelector('auro-calendar-month');
 
@@ -312,6 +314,8 @@ describe('auro-datepicker', () => {
     const el = await fixture(html`
     <auro-datepicker range></auro-datepicker>
   `);
+
+  await elementUpdated(el);
 
   const calendar = el.shadowRoot.querySelector('auro-calendar');
     const calendarMonth = calendar.shadowRoot.querySelector('auro-calendar-month');
@@ -346,7 +350,7 @@ describe('auro-datepicker', () => {
     const fullDate = `${("0" + (date.getMonth() + 1)).slice(-2)}/${("0" + (date.getDate())).slice(-2)}/${date.getFullYear()}`;
 
     const el = await fixture(html`
-      <auro-datepicker minDate="${fullDate}"></auro-datepicker>
+      <auro-datepicker calendarStartDate="${fullDate}"></auro-datepicker>
     `);
 
     const calendar = el.shadowRoot.querySelector('auro-calendar');
@@ -418,22 +422,22 @@ describe('auro-datepicker', () => {
     await expect(el.getAttribute('validity')).to.be.equal('rangeOverflow');
   });
 
-  it('changing centralDate changes month visibility', async () => {
+  it('changing calendarFocusDate changes month visibility', async () => {
     const el = await fixture(html`
-      <auro-datepicker centralDate="03/23/2023"></auro-datepicker>
+      <auro-datepicker calendarFocusDate="03/23/2023"></auro-datepicker>
     `);
-
-    const calendar = el.shadowRoot.querySelector('auro-calendar');
-
-    await expect(calendar.month).to.be.equal(3);
-    await expect(calendar.year).to.be.equal(2023);
-
-    el.centralDate = '04/25/2024';
 
     await elementUpdated(el);
 
-    await expect(calendar.month).to.be.equal(4);
-    await expect(calendar.year).to.be.equal(2024);
+    const calendar = el.shadowRoot.querySelector('auro-calendar');
+
+    await expect(calendar.centralDate).to.be.equal('03/23/2023');
+
+    el.calendarFocusDate = '04/25/2024';
+
+    await elementUpdated(el);
+
+    await expect(calendar.centralDate).to.be.equal('04/25/2024');
   });
 
   it('renders a single calendar by default', async () => {
@@ -494,9 +498,9 @@ describe('auro-datepicker', () => {
     expect(input2.value).to.equal('');
   });
 
-  it('render correct number of calendars with minDate and maxDate', async () => {
+  it('render correct number of calendars with calendarStartDate and calendarEndDate', async () => {
     const el = await fixture(html`
-      <auro-datepicker range minDate="03/04/2023" maxDate="05/05/2023"></auro-datepicker>
+      <auro-datepicker range calendarStartDate="03/04/2023" calendarEndDate="05/05/2023"></auro-datepicker>
     `);
 
     const calendar = el.shadowRoot.querySelector('auro-calendar');
@@ -514,19 +518,19 @@ describe('auro-datepicker', () => {
     const calendar = el.shadowRoot.querySelector('auro-calendar');
     const prevMonthBth = calendar.shadowRoot.querySelector('.prevMonth');
 
-    await expect(calendar.month).to.equal(2);
+    await expect(calendar.centralDate).to.equal('02/01/2023');
 
     prevMonthBth.click();
 
     await elementUpdated(el);
 
-    await expect(calendar.month).to.equal(1);
+    await expect(calendar.centralDate).to.equal('Sun Jan 01 2023 00:00:00 GMT-0800 (Pacific Standard Time)');
 
     prevMonthBth.click();
 
     await elementUpdated(el);
 
-    await expect(calendar.month).to.equal(12);
+    await expect(calendar.centralDate).to.equal('Thu Dec 01 2022 00:00:00 GMT-0800 (Pacific Standard Time)');
   });
 
   it('handleNextMonth changes current calendar month', async () => {
@@ -539,19 +543,17 @@ describe('auro-datepicker', () => {
     const calendar = el.shadowRoot.querySelector('auro-calendar');
     const nextMonthBth = calendar.shadowRoot.querySelector('.nextMonth');
 
-    await expect(calendar.month).to.equal(11);
+    await expect(calendar.centralDate).to.equal('11/01/2023');
 
     nextMonthBth.click();
 
     await elementUpdated(el);
-
-    await expect(calendar.month).to.equal(12);
+    await expect(calendar.centralDate).to.equal('Fri Dec 01 2023 00:00:00 GMT-0800 (Pacific Standard Time)');
 
     nextMonthBth.click();
 
     await elementUpdated(el);
-
-    await expect(calendar.month).to.equal(1);
+    await expect(calendar.centralDate).to.equal('Mon Jan 01 2024 00:00:00 GMT-0800 (Pacific Standard Time)');
   });
 
   it('shows dropdown when user is typing in input', async () => {
@@ -647,6 +649,8 @@ describe('auro-datepicker', () => {
     const el = await fixture(html`
       <auro-datepicker></auro-datepicker>
     `);
+
+    await elementUpdated(el);
 
     const calendar = el.shadowRoot.querySelector('auro-calendar');
     const calendarMonth = calendar.shadowRoot.querySelector('auro-calendar-month');


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Resolves:** #213

## Summary:

This is a significant refactor of the logic controlling which and how many calendar months to render.

The new system follows theses rules:

### The first calendar month that "may" be rendered is chosen in the following priority order:

1. The `calendarStartDate` is set with a valid date
1. The `minDate` is set with a valid date

### The last calendar month that "may" be rendered is chosen in the following priority order:

1. The `calendarEndDate` is set with a valid date
1. The `maxDate` is set with a valid date

### The following logic is used for choosing which months are currently rendered in DOM

In mobile the full range is rendered from the first month that "may" be rendered (as determined above) to the last month that "may" be rendered. If no range is determined using the earliers rules, the mobile calendar will start from the current date and include the next 11 months (12 months total).

In desktop, 1 month will be rendered by default. If the `range` attribute is used, this will change to 2 months. If `calendarStartDate` is set, the first month rendered will be this date. Otherwise, if `value` is set, this date will be used. Otherwise, the current date will be used. 

The desktop calendar may navigate to previous and next months. The range of navigation is restricted by `calendarStartDate` and `calendarEndDate`. If one or the other is not set, `minDate` and `maxDate` are considered next. If none of these four attributes are set, the desktop calendar may be navigated forward and backward through time as far as the user wishes.

## Type of change:

Please delete options that are not relevant.

- [x] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
