### PR TITLE
Correctly handle focus date when values are set

### DIFF
--- a/demo/api.md
+++ b/demo/api.md
@@ -109,9 +109,9 @@ In <strong>desktop</strong>, the calendar month navigation will be restricted by
 Note: This does not restrict setting a value outside of those date constraints. These properties _only_ define which months can be rendered in the calendar. A user may still type any date into the input field. If actual value selection restrictions are needed, see the `minDate` and `maxDate` properties which may be used standalone, or in conjunction with `calendarStartDate` and `calendarEndDate`.
 
 <div class="exampleWrapper">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/calendarFocusDate.html) -->
-  <!-- The below content is automatically added from ./../../apiExamples/calendarFocusDate.html -->
-  <auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="12/01/2023" calendarFocusDate="11/01/2022">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/calendarStartAndEndDate.html) -->
+  <!-- The below content is automatically added from ./../../apiExamples/calendarStartAndEndDate.html -->
+  <auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="06/01/2022">
     <span slot="fromLabel">Choose a date</span>
     <span slot="mobileDateLabel">Choose a date</span>
   </auro-datepicker>
@@ -119,11 +119,11 @@ Note: This does not restrict setting a value outside of those date constraints. 
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../../apiExamples/calendarFocusDate.html) -->
-<!-- The below code snippet is automatically added from ./../../apiExamples/calendarFocusDate.html -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../../apiExamples/calendarStartAndEndDate.html) -->
+<!-- The below code snippet is automatically added from ./../../apiExamples/calendarStartAndEndDate.html -->
 
 ```html
-<auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="12/01/2023" calendarFocusDate="11/01/2022">
+<auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="06/01/2022">
   <span slot="fromLabel">Choose a date</span>
   <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>

--- a/demo/api.md
+++ b/demo/api.md
@@ -10,6 +10,7 @@
 | [calendarEndDate](#calendarEndDate)                 | `calendarEndDate`                 | `String`  | "undefined"                                      | The last date that may be displayed in the calendar |
 | [calendarFocusDate](#calendarFocusDate)               | `calendarFocusDate`               | `String`  | "value"                                          | The date that will first be visually rendered to the user in the calendar. |
 | [calendarStartDate](#calendarStartDate)               | `calendarStartDate`               | `String`  | "undefined"                                      | The first date that may be displayed in the calendar. |
+| [centralDate](#centralDate)                     | `centralDate`                     | `String`  |                                                  | The date that determines the currently visible month. |
 | [disabled](#disabled)                        | `disabled`                        | `Boolean` | false                                            | If set, disables the datepicker.                 |
 | [error](#error)                           | `error`                           | `String`  |                                                  | When defined, sets persistent validity to `customError` and sets `setCustomValidity` = attribute value. |
 | [maxDate](#maxDate)                         | `maxDate`                         | `String`  |                                                  | Maximum date. All dates after will be disabled.  |

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,7 @@
 | `calendarEndDate`                 | `calendarEndDate`                 | `String`  | "undefined"                                      | The last date that may be displayed in the calendar |
 | `calendarFocusDate`               | `calendarFocusDate`               | `String`  | "value"                                          | The date that will first be visually rendered to the user in the calendar. |
 | `calendarStartDate`               | `calendarStartDate`               | `String`  | "undefined"                                      | The first date that may be displayed in the calendar. |
+| `centralDate`                     | `centralDate`                     | `String`  |                                                  | The date that determines the currently visible month. |
 | `disabled`                        | `disabled`                        | `Boolean` | false                                            | If set, disables the datepicker.                 |
 | `error`                           | `error`                           | `String`  |                                                  | When defined, sets persistent validity to `customError` and sets `setCustomValidity` = attribute value. |
 | `maxDate`                         | `maxDate`                         | `String`  |                                                  | Maximum date. All dates after will be disabled.  |

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -33,13 +33,13 @@ In <strong>desktop</strong>, the calendar month navigation will be restricted by
 Note: This does not restrict setting a value outside of those date constraints. These properties _only_ define which months can be rendered in the calendar. A user may still type any date into the input field. If actual value selection restrictions are needed, see the `minDate` and `maxDate` properties which may be used standalone, or in conjunction with `calendarStartDate` and `calendarEndDate`.
 
 <div class="exampleWrapper">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/calendarFocusDate.html) -->
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/calendarStartAndEndDate.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../../apiExamples/calendarFocusDate.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../../apiExamples/calendarStartAndEndDate.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/src/auro-calendar-cell.js
+++ b/src/auro-calendar-cell.js
@@ -327,7 +327,7 @@ export class AuroCalendarCell extends LitElement {
       'currentDate': this.currentDate,
       'selected': this.selected,
       'inRange': this.hovered && this.isInRange(this.day, this.dateFrom, this.dateTo),
-      'lastHoveredDate': this.isLastHoveredDate(this.day, this.dateFrom, this.dateTo, this.hoveredDate) && this.datepicker.hasAttribute('range'),
+      'lastHoveredDate': this.isLastHoveredDate(this.day, this.dateFrom, this.dateTo, this.hoveredDate) && this.datepicker && this.datepicker.hasAttribute('range'),
       'disabled': this.isEnabled(this.day, this.min, this.max, this.disabledDays),
       'rangeDepartDate': this.isDepartDate(this.day, this.dateFrom) && (this.hoveredDate > this.dateFrom || this.dateTo),
       'rangeReturnDate': this.isReturnDate(this.day, this.dateFrom, this.dateTo),

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,6 +1,22 @@
 export class AuroDatepickerUtilities {
 
   /**
+   * Returns true if value passed in is a valid date.
+   * @private
+   * @param {String} date - Date to validate.
+   * @returns {Boolean}
+   */
+  validDateStr(date) {
+    const dateStrLength = 10;
+
+    if (date.length === dateStrLength && Date.parse(date)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
    * Converts any date object to a date object representing the first day of the month.
    * @param {Object} date - Date to convert to the first day of the month.
    * @returns {Object} Returns the auro-calendar-months HTML.

--- a/src/utilitiesCalendar.js
+++ b/src/utilitiesCalendar.js
@@ -7,18 +7,22 @@ export class CalendarUtilities {
 
 
   /**
-   * Scroll the calendar month list to a given date.
+   * Scroll the calendar month list to a given valid date if in mobile view.
    * @param {Object} elem - The calendar element.
    * @param {String} date - The date to scroll into view.
    * @returns {void}
    */
   scrollMonthIntoView(elem, date) {
-    const month = new Date(date).getMonth() + 1;
-    const year = new Date(date).getFullYear();
-    const selector = `#month-${month}-${year}`;
-    const monthElem = elem.shadowRoot.querySelector(selector);
+    const mobileLayout = window.innerWidth < elem.mobileBreakpoint;
 
-    monthElem.scrollIntoView();
+    if (this.util.validDateStr(date) && mobileLayout) {
+      const month = new Date(date).getMonth() + 1;
+      const year = new Date(date).getFullYear();
+      const selector = `#month-${month}-${year}`;
+      const monthElem = elem.shadowRoot.querySelector(selector);
+
+      monthElem.scrollIntoView();
+    }
   }
 
   /**

--- a/src/utilitiesCalendarRender.js
+++ b/src/utilitiesCalendarRender.js
@@ -7,6 +7,20 @@ export class UtilitiesCalendarRender {
   }
 
   /**
+   * Attempt to update the central date but only if the date is a valid date.
+   * @param {Object} elem - The element to set the centralDate on.
+   * @param {String} date - The date to set the centralDate to.
+   * @private
+   */
+  updateCentralDate(elem, date) {
+    const dateObj = new Date(date);
+
+    if (!isNaN(dateObj)) {
+      elem.centralDate = dateObj;
+    }
+  }
+
+  /**
    * Determine how many months to render based on the defined calendar range.
    * @param {Object} elem - The auro-calendar element.
    * @private

--- a/test/auro-datepicker.test.js
+++ b/test/auro-datepicker.test.js
@@ -271,10 +271,8 @@ describe('auro-datepicker', () => {
 
   it('updates centralDate when minDate is later than centralDate', async () => {
     const el = await fixture(html`
-      <auro-datepicker></auro-datepicker>
+      <auro-datepicker calendarFocusDate="03/02/2023"></auro-datepicker>
     `);
-
-    el.centralDate = '03/02/2023';
 
     await elementUpdated(el);
 
@@ -282,7 +280,10 @@ describe('auro-datepicker', () => {
 
     await elementUpdated(el);
 
-    await expect(el.centralDate).to.be.equal(el.minDate);
+    const central = `${("0" + (new Date(el.centralDate).getMonth() + 1)).slice(-2)}/${("0" + new Date(el.centralDate).getDate()).slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+    const min = el.minDate;
+
+    await expect(min).to.be.equal(central);
   });
 
   it('selecting a dateFrom date by clicking on the calendar sets the correct value', async () => {
@@ -431,13 +432,17 @@ describe('auro-datepicker', () => {
 
     const calendar = el.shadowRoot.querySelector('auro-calendar');
 
-    await expect(calendar.centralDate).to.be.equal('03/23/2023');
+    const central = `${("0" + (new Date(el.centralDate).getMonth() + 1)).slice(-2)}/${("0" + new Date(el.centralDate).getDate()).slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+    await expect(central).to.be.equal('03/23/2023');
 
     el.calendarFocusDate = '04/25/2024';
 
     await elementUpdated(el);
 
-    await expect(calendar.centralDate).to.be.equal('04/25/2024');
+    const centralAfter = `${("0" + (new Date(el.centralDate).getMonth() + 1)).slice(-2)}/${("0" + new Date(el.centralDate).getDate()).slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+    await expect(centralAfter).to.be.equal('04/25/2024');
   });
 
   it('renders a single calendar by default', async () => {
@@ -518,19 +523,25 @@ describe('auro-datepicker', () => {
     const calendar = el.shadowRoot.querySelector('auro-calendar');
     const prevMonthBth = calendar.shadowRoot.querySelector('.prevMonth');
 
-    await expect(calendar.centralDate).to.equal('02/01/2023');
+    const central = `${("0" + (new Date(el.centralDate).getMonth() + 1)).slice(-2)}/${("0" + new Date(el.centralDate).getDate()).slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+    await expect(central).to.equal('02/01/2023');
 
     prevMonthBth.click();
 
     await elementUpdated(el);
 
-    await expect(calendar.centralDate).to.contain('Jan 01 2023');
+    const centralAfter = `${("0" + (new Date(el.centralDate).getMonth() + 1)).slice(-2)}/${("0" + new Date(el.centralDate).getDate()).slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+    await expect(centralAfter).to.contain('01/01/2023');
 
     prevMonthBth.click();
 
     await elementUpdated(el);
 
-    await expect(calendar.centralDate).to.contain('Dec 01 2022');
+    const centralAfterAgain = `${("0" + (new Date(el.centralDate).getMonth() + 1)).slice(-2)}/${("0" + new Date(el.centralDate).getDate()).slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+    await expect(centralAfterAgain).to.contain('12/01/2022');
   });
 
   it('handleNextMonth changes current calendar month', async () => {
@@ -543,17 +554,25 @@ describe('auro-datepicker', () => {
     const calendar = el.shadowRoot.querySelector('auro-calendar');
     const nextMonthBth = calendar.shadowRoot.querySelector('.nextMonth');
 
-    await expect(calendar.centralDate).to.equal('11/01/2023');
+    const central = `${("0" + (new Date(el.centralDate).getMonth() + 1)).slice(-2)}/${("0" + new Date(el.centralDate).getDate()).slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+    await expect(central).to.equal('11/01/2023');
 
     nextMonthBth.click();
 
     await elementUpdated(el);
-    await expect(calendar.centralDate).to.contain('Dec 01 2023');
+    
+    const centralAfter = `${("0" + (new Date(el.centralDate).getMonth() + 1)).slice(-2)}/${("0" + new Date(el.centralDate).getDate()).slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+    await expect(centralAfter).to.contain('12/01/2023');
 
     nextMonthBth.click();
 
     await elementUpdated(el);
-    await expect(calendar.centralDate).to.contain('Jan 01 2024');
+
+    const centralAfterAgain = `${("0" + (new Date(el.centralDate).getMonth() + 1)).slice(-2)}/${("0" + new Date(el.centralDate).getDate()).slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+    await expect(centralAfterAgain).to.contain('01/01/2024');
   });
 
   it('shows dropdown when user is typing in input', async () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Resolves:** #225 

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

The changes made in this code diff primarily involve the following updates:

1. **Importing a New Module**:
   - Added the import statement for `UtilitiesCalendarRender`:
     ```javascript
     import { UtilitiesCalendarRender } from './utilitiesCalendarRender';
     ```

2. **Introducing `calendarRenderUtil`**:
   - A new private property `calendarRenderUtil` is instantiated using `UtilitiesCalendarRender`:
     ```javascript
     this.calendarRenderUtil = new UtilitiesCalendarRender();
     ```

3. **Replacing `centralDate` Logic**:
   - The property `centralDate` has been removed, and its logic has been replaced with methods from `calendarRenderUtil` to update the central date.

4. **Initial Central Date Setup**:
   - Added logic to initialize the central date using `calendarRenderUtil` based on the attribute `calendarStartDate`:
     ```javascript
     if (this.getAttribute('calendarStartDate') && this.util.validDateStr(this.getAttribute('calendarStartDate'))) {
       this.calendarRenderUtil.updateCentralDate(this, this.getAttribute('calendarStartDate'));
     } else {
       this.calendarRenderUtil.updateCentralDate(this, new Date());
     }
     ```

5. **Date Validation Method Update**:
   - Removed the method `validDateStr` from `AuroDatePicker` and replaced its usage with `this.util.validDateStr`.

6. **Handling Date Changes**:
   - Updated several instances where `centralDate` was directly set to instead use `this.calendarRenderUtil.updateCentralDate`.

7. **Validation and Conditional Logic**:
   - Adjusted various conditions to validate dates and set the focus date, making use of `this.util.validDateStr` and `this.calendarRenderUtil.updateCentralDate`.

**Specific Changes Include**:

- Initialization of `calendarRenderUtil` in the constructor.
- Replacing direct assignments to `centralDate` with calls to `calendarRenderUtil.updateCentralDate`.
- Ensuring date validations use `this.util.validDateStr` instead of the removed `validDateStr`.
- Handling date changes and updates within the component using the new utility methods.

These changes streamline the handling of calendar rendering and date validation by delegating these responsibilities to the new `UtilitiesCalendarRender` and the existing `AuroDatepickerUtilities` utility classes. This likely improves code modularity and reusability.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

## How to Validate

- Follow the given steps in the issue ticket that would reproduce the error and make sure the date in calendar matches full date in the input
- Switch to mobile and test the `calendarStart/EndDate` and `calendarFocusDate` examples to make sure the calendar is rendering the correct months and that the month being displayed when the calendar opens is correct

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
