### PR TITLE
Add "hide()" method to datepicker to close calendar

### DIFF
--- a/demo/api.md
+++ b/demo/api.md
@@ -32,18 +32,19 @@
 | Method            | Type                         | Description                                      |
 |-------------------|------------------------------|--------------------------------------------------|
 | [focus](#focus)           | `(focusInput: string): void` | Focuses the datepicker trigger input.<br /><br />**focusInput**: Pass in `endDate` to focus on the return input. No parameter is needed to focus on the depart input. |
+| [hide](#hide)            | `(): void`                   | Hides the datepicker's calendar.                 |
 | [pushSlotContent](#pushSlotContent) | `(): void`                   | Emits an event to notify the calendar cells to fetch their slot content. |
 
 ## Events
 
-| Event                           | Type                                             | Description                                      |
-|---------------------------------|--------------------------------------------------|--------------------------------------------------|
-| `auroDatePicker-monthChanged`   | `CustomEvent<{ month: any; year: any; numCalendars: any; }>` | Notifies that the visible calendar month(s) have changed. |
-| `auroDatePicker-newSlotContent` | `CustomEvent<any>`                               | Notifies that new slot content has been added to the datepicker. |
-| `auroDatePicker-ready`          | `CustomEvent<any>`                               | Notifies that the component has finished initializing. |
-| `auroDatePicker-toggled`        | `CustomEvent<{ expanded: any; }>`                | Notifies that the calendar dropdown has been opened/closed. |
-| `auroDatePicker-valueSet`       |                                                  | Notifies that the component has a new value set. |
-| `auroFormElement-validated`     |                                                  | Notifies that the component value(s) have been validated. |
+| Event                           | Type                              | Description                                      |
+|---------------------------------|-----------------------------------|--------------------------------------------------|
+| `auroDatePicker-monthChanged`   | `CustomEvent<any>`                | Notifies that the visible calendar month(s) have changed. |
+| `auroDatePicker-newSlotContent` | `CustomEvent<any>`                | Notifies that new slot content has been added to the datepicker. |
+| `auroDatePicker-ready`          | `CustomEvent<any>`                | Notifies that the component has finished initializing. |
+| `auroDatePicker-toggled`        | `CustomEvent<{ expanded: any; }>` | Notifies that the calendar dropdown has been opened/closed. |
+| `auroDatePicker-valueSet`       |                                   | Notifies that the component has a new value set. |
+| `auroFormElement-validated`     |                                   | Notifies that the component value(s) have been validated. |
 
 ## Slots
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,18 +29,19 @@
 | Method            | Type                         | Description                                      |
 |-------------------|------------------------------|--------------------------------------------------|
 | `focus`           | `(focusInput: string): void` | Focuses the datepicker trigger input.<br /><br />**focusInput**: Pass in `endDate` to focus on the return input. No parameter is needed to focus on the depart input. |
+| `hide`            | `(): void`                   | Hides the datepicker's calendar.                 |
 | `pushSlotContent` | `(): void`                   | Emits an event to notify the calendar cells to fetch their slot content. |
 
 ## Events
 
-| Event                           | Type                                             | Description                                      |
-|---------------------------------|--------------------------------------------------|--------------------------------------------------|
-| `auroDatePicker-monthChanged`   | `CustomEvent<{ month: any; year: any; numCalendars: any; }>` | Notifies that the visible calendar month(s) have changed. |
-| `auroDatePicker-newSlotContent` | `CustomEvent<any>`                               | Notifies that new slot content has been added to the datepicker. |
-| `auroDatePicker-ready`          | `CustomEvent<any>`                               | Notifies that the component has finished initializing. |
-| `auroDatePicker-toggled`        | `CustomEvent<{ expanded: any; }>`                | Notifies that the calendar dropdown has been opened/closed. |
-| `auroDatePicker-valueSet`       |                                                  | Notifies that the component has a new value set. |
-| `auroFormElement-validated`     |                                                  | Notifies that the component value(s) have been validated. |
+| Event                           | Type                              | Description                                      |
+|---------------------------------|-----------------------------------|--------------------------------------------------|
+| `auroDatePicker-monthChanged`   | `CustomEvent<any>`                | Notifies that the visible calendar month(s) have changed. |
+| `auroDatePicker-newSlotContent` | `CustomEvent<any>`                | Notifies that new slot content has been added to the datepicker. |
+| `auroDatePicker-ready`          | `CustomEvent<any>`                | Notifies that the component has finished initializing. |
+| `auroDatePicker-toggled`        | `CustomEvent<{ expanded: any; }>` | Notifies that the calendar dropdown has been opened/closed. |
+| `auroDatePicker-valueSet`       |                                   | Notifies that the component has a new value set. |
+| `auroFormElement-validated`     |                                   | Notifies that the component value(s) have been validated. |
 
 ## Slots
 

--- a/src/auro-datepicker.js
+++ b/src/auro-datepicker.js
@@ -409,19 +409,13 @@ export class AuroDatePicker extends LitElement {
 
   /**
    * Sends event notifying that the calendar's visible month has changed.
-   * @param {Object} event - Event passed in from auro-calendar when the event triggered this function.
    * @private
    * @returns {void}
    */
-  notifyMonthChanged(event) {
+  notifyMonthChanged() {
     this.dispatchEvent(new CustomEvent('auroDatePicker-monthChanged', {
       bubbles: true,
       composed: true,
-      detail: {
-        month: event.detail.month,
-        year: event.detail.year,
-        numCalendars: event.detail.numCalendars,
-      },
     }));
   }
 
@@ -671,6 +665,15 @@ export class AuroDatePicker extends LitElement {
    */
   pushSlotContent() {
     this.dispatchEvent(new CustomEvent('auroDatePicker-newSlotContent'));
+  }
+
+  /**
+   * Hides the datepicker's calendar.
+   * @returns {void}
+   */
+  hide() {
+    this.dropdown = this.shadowRoot.querySelector(this.dropdownTag._$litStatic$);
+    this.dropdown.hide();
   }
 
   updated(changedProperties) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Adds a public `hide()` method that invokes the same `hide()` method onto the datepicker's auro-dropdown component to close the calendar.

This should resolve the feature request below and allow consumers of datepicker to close the calendar without needing to query select within the datepicker's shadow root.

**Resolves:** #236

## Summary:

Adds a `hide()` method inside the `AuroDatePicker` class that calls `hide()` on the datepicker's auro-dropdown component.

## Type of change:

Please delete options that are not relevant.

- [X] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
