### PR TITLE
Update calendar cell date slot text colors for lowest price highlighting

### DIFF
--- a/demo/api.md
+++ b/demo/api.md
@@ -49,7 +49,7 @@
 
 | Name                 | Description                                      |
 |----------------------|--------------------------------------------------|
-| `date_MM_DD_YYYY`    | Defines the content to display in the auro-calendar-cell for the specified date. |
+| `date_MM_DD_YYYY`    | Defines the content to display in the auro-calendar-cell for the specified date. The content text is highlighted green when the `highlight` attribute is used on the slot. |
 | [fromLabel](#fromLabel)          | Defines the label content for the first input.   |
 | [helpText](#helpText)           | Defines the content of the helpText.             |
 | [mobileDateLabel](#mobileDateLabel)    | Defines the content to display above selected dates in the mobile layout. |
@@ -809,6 +809,8 @@ Only for use with the `range` attribute. Sets the label for the second input.
 
 Custom content can be added to any day in the calendar using a `slot` named following the pattern `date_{MM}_{DD}_{YYYY}` (e.g. `date_01_08_2024`).
 
+Adding the `highlight` attribute to the slot will change the slot content's color to `var(--ds-color-text-success-default`.
+
 Slot content support is limited to text only and a maximum of five (5) characters.
 
 Slot content can be styled using [inline styles](https://www.codecademy.com/article/html-inline-styles) or [CSS Parts](https://css-tricks.com/styling-in-the-shadow-dom-with-css-shadow-parts/) (`part="dateSlot"`).
@@ -820,7 +822,7 @@ Slot content can be styled using [inline styles](https://www.codecademy.com/arti
     <span slot="fromLabel">Choose a date</span>
     <span slot="mobileDateLabel">Choose a date</span>
     <span slot="date_12_03_2023">Sold</span>
-    <span slot="date_12_04_2023">$89</span>
+    <span highlight slot="date_12_04_2023">$89</span>
     <span slot="date_12_05_2023">$100</span>
     <span slot="date_12_06_2023">$2345</span>
     <span slot="date_12_07_2023">$149</span>
@@ -839,7 +841,7 @@ Slot content can be styled using [inline styles](https://www.codecademy.com/arti
   <span slot="fromLabel">Choose a date</span>
   <span slot="mobileDateLabel">Choose a date</span>
   <span slot="date_12_03_2023">Sold</span>
-  <span slot="date_12_04_2023">$89</span>
+  <span highlight slot="date_12_04_2023">$89</span>
   <span slot="date_12_05_2023">$100</span>
   <span slot="date_12_06_2023">$2345</span>
   <span slot="date_12_07_2023">$149</span>

--- a/demo/api.md
+++ b/demo/api.md
@@ -809,7 +809,7 @@ Only for use with the `range` attribute. Sets the label for the second input.
 
 Custom content can be added to any day in the calendar using a `slot` named following the pattern `date_{MM}_{DD}_{YYYY}` (e.g. `date_01_08_2024`).
 
-Adding the `highlight` attribute to the slot will change the slot content's color to `var(--ds-color-text-success-default`.
+Adding the `highlight` attribute to the slot will change the slot content's color to `var(--ds-color-text-success-default)`.
 
 Slot content support is limited to text only and a maximum of five (5) characters.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-datepicker",
-  "version": "2.6.0",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-datepicker",
-      "version": "2.6.0",
+      "version": "2.6.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/style-auro-calendar-cell.scss
+++ b/src/style-auro-calendar-cell.scss
@@ -122,7 +122,7 @@
 }
 
 ::slotted([slot^="date_"]) {
-  color: var(--ds-color-text-link-default, $ds-color-text-link-default);
+  color: var(--ds-color-text-primary-default, $ds-color-text-primary-default);
 
   position: absolute;
   top: 80%;
@@ -134,6 +134,10 @@
   white-space: nowrap;
 
   transform: translate(-50%, -50%);
+}
+
+::slotted([slot^="date_"][highlight]) {
+  color: var(--ds-color-text-success-default, $ds-color-text-success-default);
 }
 
 :host([disabled]) ::slotted([slot^="date_"]) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Resolves:** #241

## Summary:

Updates the calendar cell date slot text to use `var(--ds-color-text-primary-default)` by default and `var(--ds-color-text-success-default)` when the slot is used with the `highlight` attribute

![image](https://github.com/user-attachments/assets/51ac985b-6b47-4474-9e8b-4a3fbd1e2cda)

## Type of change:

- [X] New capability
- [X] Revision of an existing capability

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
