### PR TITLE
fix: moves auro library to dependencies in package.json #261

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-datepicker",
-  "version": "2.8.0-beta.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-datepicker",
-      "version": "2.8.0-beta.1",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -14,6 +14,7 @@
         "@aurodesignsystem/auro-dropdown": "^3.0.0",
         "@aurodesignsystem/auro-formvalidation": "^1.0.3",
         "@aurodesignsystem/auro-input": "^4.0.0",
+        "@aurodesignsystem/auro-library": "^2.8.0",
         "@aurodesignsystem/auro-popover": "^4.0.0",
         "@material/mwc-icon-button": "^0.27.0",
         "@material/mwc-list": "^0.27.0",
@@ -23,7 +24,6 @@
         "wc-range-datepicker": "^1.3.0"
       },
       "devDependencies": {
-        "@aurodesignsystem/auro-library": "^2.8.0",
         "@aurodesignsystem/design-tokens": "^4.10.0",
         "@aurodesignsystem/eslint-config": "^1.3.2",
         "@aurodesignsystem/webcorestylesheets": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@aurodesignsystem/auro-dropdown": "^3.0.0",
     "@aurodesignsystem/auro-formvalidation": "^1.0.3",
     "@aurodesignsystem/auro-input": "^4.0.0",
+    "@aurodesignsystem/auro-library": "^2.8.0",
     "@aurodesignsystem/auro-popover": "^4.0.0",
     "@material/mwc-icon-button": "^0.27.0",
     "@material/mwc-list": "^0.27.0",
@@ -37,7 +38,6 @@
     "@aurodesignsystem/webcorestylesheets": "^5.1.2"
   },
   "devDependencies": {
-    "@aurodesignsystem/auro-library": "^2.8.0",
     "@aurodesignsystem/design-tokens": "^4.10.0",
     "@aurodesignsystem/eslint-config": "^1.3.2",
     "@aurodesignsystem/webcorestylesheets": "^5.1.2",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Moves Auro Library into `dependencies` from `devDependencies` to avoid installation issues, as originally reported in [#573](https://github.com/AlaskaAirlines/WC-Generator/issues/573).

**Resolves:** #261 

## Summary:

- Moved to `dependencies` within `package.json`
- Regenerated `package.lock`
- Verified `build` and `test` ran successfully

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team